### PR TITLE
tmuxinator executes attackmate with --json flag

### DIFF
--- a/templates/attackmate-tmux.j2
+++ b/templates/attackmate-tmux.j2
@@ -25,4 +25,4 @@ then
 	tmux send-keys -t "$session" "source ${project_path}/venv/bin/activate" Enter
 fi
 
-tmux send-keys -t "$pane" "attackmate $@" Enter
+tmux send-keys -t "$pane" "attackmate $@ --json" Enter


### PR DESCRIPTION
requested by Max. 
attackmate.json logs are easier to parse and should therefore be generated by default