### PR TITLE
enable passing additional command line arguments

### DIFF
--- a/templates/attackmate-tmux.j2
+++ b/templates/attackmate-tmux.j2
@@ -25,4 +25,5 @@ then
 	tmux send-keys -t "$session" "source ${project_path}/venv/bin/activate" Enter
 fi
 
-tmux send-keys -t "$pane" "attackmate $@" Enter
+full_command="attackmate $*"
+tmux send-keys -t "$pane" "${full_command}" Enter


### PR DESCRIPTION
enable passing additional comand line arguments to attackmate. previously 
`/usr/local/bin/attackmate-tmux scenario_1_a_a.yml --json` would have resulted in 
attackmate-tmux scenario_1_a_a.yml--json  

--> one string interpreted as playbook filepath